### PR TITLE
only draw contour shade for real osm polygons

### DIFF
--- a/ocitysmap/layoutlib/single_page_renderers.py
+++ b/ocitysmap/layoutlib/single_page_renderers.py
@@ -142,7 +142,7 @@ class SinglePageRenderer(Renderer):
             float(self._map_coords[2]),  # W
             float(self._map_coords[3]),  # H
             dpi,
-            rc.osmid != 0 # only if we have a real contour polygon
+            rc.osmid != None 
 	    )
 
         # Prepare the grid

--- a/ocitysmap/layoutlib/single_page_renderers.py
+++ b/ocitysmap/layoutlib/single_page_renderers.py
@@ -141,7 +141,9 @@ class SinglePageRenderer(Renderer):
         self._map_canvas = self._create_map_canvas(
             float(self._map_coords[2]),  # W
             float(self._map_coords[3]),  # H
-            dpi )
+            dpi,
+            rc.osmid != 0 # only if we have a real contour polygon
+	    )
 
         # Prepare the grid
         self.grid = self._create_grid(self._map_canvas)

--- a/ocitysmap/layoutlib/single_page_renderers.py
+++ b/ocitysmap/layoutlib/single_page_renderers.py
@@ -142,7 +142,7 @@ class SinglePageRenderer(Renderer):
             float(self._map_coords[2]),  # W
             float(self._map_coords[3]),  # H
             dpi,
-            rc.osmid != None 
+            rc.osmid is not None 
 	    )
 
         # Prepare the grid


### PR DESCRIPTION
Only draw contour shade for real osm polygons, not for simple rectangular bounding box

When just selecting a bounding box in the web interface the exact area is not really important, and as the aspect ratio of the selection will usually not match that of the map canvas rendering area this leeds to confusing dark strips at the top and bottom, or left and right, of the rendered map, depending on which direction the selecting bounding box is extended to to fill the render canvas
