### PR TITLE
add support for rendering an extra overlay on top of the base map

### DIFF
--- a/ocitysmap/__init__.py
+++ b/ocitysmap/__init__.py
@@ -111,6 +111,7 @@ class RenderingConfiguration:
         self.language        = None # str (locale)
 
         self.stylesheet      = None # Obj Stylesheet
+        self.overlay         = None # Obj Stylesheet
 
         self.paper_width_mm  = None
         self.paper_height_mm = None

--- a/ocitysmap/__init__.py
+++ b/ocitysmap/__init__.py
@@ -183,9 +183,10 @@ class Stylesheet:
 
     @staticmethod
     def create_all_from_config(parser, type='stylesheets'):
-        styles = parser.get('rendering', 'available_'+type)
-        if not styles:
-	    return []
+        try:
+            styles = parser.get('rendering', 'available_'+type)
+        except (ConfigParser.NoOptionError, ValueError):
+            return []
 
         return [Stylesheet.create_from_config_section(parser, name.strip())
                 for name in styles.split(',')]

--- a/ocitysmap/layoutlib/single_page_renderers.py
+++ b/ocitysmap/layoutlib/single_page_renderers.py
@@ -41,6 +41,7 @@ from ocitysmap.indexlib.renderer import StreetIndexRenderer
 from indexlib.indexer import StreetIndex
 from indexlib.commons import IndexDoesNotFitError, IndexEmptyError
 import draw_utils
+from ocitysmap.maplib.map_canvas import MapCanvas
 
 LOG = logging.getLogger('ocitysmap')
 
@@ -142,6 +143,14 @@ class SinglePageRenderer(Renderer):
             float(self._map_coords[2]),  # W
             float(self._map_coords[3]),  # H
             dpi )
+
+        # Prepare map overlay
+        if self.rc.overlay:
+            self._overlay_canvas = MapCanvas(self.rc.overlay,
+                                             self.rc.bounding_box,
+                                             float(self._map_coords[2]),  # W
+                                             float(self._map_coords[3]),  # H
+                                             dpi)
 
         # Prepare the grid
         self.grid = self._create_grid(self._map_canvas)
@@ -402,10 +411,19 @@ class SinglePageRenderer(Renderer):
         # Draw the rescaled Map
         ctx.save()
         rendered_map = self._map_canvas.get_rendered_map()
+        LOG.debug('Map:')
         LOG.debug('Mapnik scale: 1/%f' % rendered_map.scale_denominator())
         LOG.debug('Actual scale: 1/%f' % self._map_canvas.get_actual_scale())
         mapnik.render(rendered_map, ctx)
         ctx.restore()
+
+        # Draw the rescaled Overlay
+        if self.rc.overlay:
+            ctx.save()
+            rendered_overlay = self._overlay_canvas.get_rendered_map()
+            LOG.debug('Overlay:')
+            mapnik.render(rendered_overlay, ctx)
+            ctx.restore()
 
         # Draw a rectangle around the map
         ctx.rectangle(0, 0, map_coords_dots[2], map_coords_dots[3])

--- a/ocitysmap/layoutlib/single_page_renderers.py
+++ b/ocitysmap/layoutlib/single_page_renderers.py
@@ -166,6 +166,11 @@ class SinglePageRenderer(Renderer):
         # Commit the internal rendering stack of the map
         self._map_canvas.render()
 
+        if self.rc.overlay:
+           self._overlay_canvas.render()
+
+
+
 
     def _create_index_rendering(self, on_the_side):
         """

--- a/render.py
+++ b/render.py
@@ -165,11 +165,11 @@ def main():
         overlay = None
     else:
         try:
-            overlay = mapper.get_stylesheet_by_name(options.overlay)
+            overlay = mapper.get_overlay_by_name(options.overlay)
         except LookupError, ex:
-            parser.error("%s. Available stylesheets: %s."
+            parser.error("%s. Available overlay stylesheets: %s."
                  % (ex, ', '.join(map(lambda s: s.name,
-                      mapper.STYLESHEET_REGISTRY))))
+                      mapper.OVERLAY_REGISTRY))))
 
     # Parse rendering layout
     if options.layout is None:

--- a/render.py
+++ b/render.py
@@ -83,6 +83,10 @@ def main():
                       metavar='NAME',
                       help='specify which stylesheet to use. Defaults to the '
                       'first specified in the configuration file.')
+    parser.add_option('--overlay', dest='overlay',
+                      metavar='NAME',
+                      help='specify which overlay stylesheet to use. '
+                      'Defaults to none')
     parser.add_option('-l', '--layout', dest='layout',
                       metavar='NAME',
                       default=KNOWN_RENDERERS_NAMES[0].split()[0],
@@ -151,6 +155,17 @@ def main():
     else:
         try:
             stylesheet = mapper.get_stylesheet_by_name(options.stylesheet)
+        except LookupError, ex:
+            parser.error("%s. Available stylesheets: %s."
+                 % (ex, ', '.join(map(lambda s: s.name,
+                      mapper.STYLESHEET_REGISTRY))))
+
+    # Parse overlay stylesheet (defaults to none)
+    if options.overlay is None:
+        overlay = None
+    else:
+        try:
+            overlay = mapper.get_stylesheet_by_name(options.overlay)
         except LookupError, ex:
             parser.error("%s. Available stylesheets: %s."
                  % (ex, ', '.join(map(lambda s: s.name,
@@ -226,6 +241,7 @@ def main():
     rc.bounding_box = bbox
     rc.language     = options.language
     rc.stylesheet   = stylesheet
+    rc.overlay      = overlay
     if options.orientation == 'portrait':
         rc.paper_width_mm  = paper_descr[1]
         rc.paper_height_mm = paper_descr[2]


### PR DESCRIPTION
Allow to select a 2nd style -- from those defined in the config file -- to be rendered on top of the base style as an overlay. Added "--overlay" option to the render script to select an overlay on the command line.
