### PR TITLE
Prevent map background from filling the full canvas

### DIFF
--- a/ocitysmap/layoutlib/multi_page_renderer.py
+++ b/ocitysmap/layoutlib/multi_page_renderer.py
@@ -435,6 +435,10 @@ class MultiPageRenderer(Renderer):
         ctx.save()
         ctx.translate(0, 0.3 * h + Renderer.PRINT_SAFE_MARGIN_PT)
 
+        # prevent map background from filling the full canvas
+        ctx.rectangle(0, 0, w, h / 2)
+        ctx.clip()
+
         # Render the map !
         mapnik.render(self._front_page_map.get_rendered_map(), ctx)
         ctx.restore()

--- a/ocitysmap/layoutlib/single_page_renderers.py
+++ b/ocitysmap/layoutlib/single_page_renderers.py
@@ -396,6 +396,10 @@ class SinglePageRenderer(Renderer):
         ##
         ctx.save()
 
+        # prevent map background from filling the full canvas
+        ctx.rectangle(map_coords_dots[0], map_coords_dots[1], map_coords_dots[2], map_coords_dots[3])
+        ctx.clip()
+
         # Prepare to draw the map at the right location
         ctx.translate(map_coords_dots[0], map_coords_dots[1])
 


### PR DESCRIPTION
The cairo_renderer in recent Mapnik versions fills
the map background with the background_color
set in the active stylesheet.

By setting a clip area before calling mapnik.render()
we restrict the background filling to the area we
actually want to have the map in. Otherwise it would
fill the whole canvas and so paint over already
existing features.

See also: https://github.com/mapnik/mapnik/commit/12dfcef3a025437ca66ac7b0a26d2d99831c978a
